### PR TITLE
FIX: ws_sr_constancia_inscripcion

### DIFF
--- a/l10n_ar_afipws/models/afipws_connection.py
+++ b/l10n_ar_afipws/models/afipws_connection.py
@@ -56,6 +56,7 @@ class AfipwsConnection(models.Model):
             ("ws_sr_padron_a5", "Servicio de Consulta de Padrón Alcance 5"),
             ("ws_sr_padron_a10", "Servicio de Consulta de Padrón Alcance 10"),
             ("ws_sr_padron_a100", "Servicio de Consulta de Padrón Alcance 100"),
+            ("ws_sr_constancia_inscripcion", "Servicio de consulta de constancia de inscripción"),
             ("wsfecred", "Servicio de Consulta para facturas de credito"),
         ],
         "AFIP WS",
@@ -100,6 +101,17 @@ class AfipwsConnection(models.Model):
                     "personaServiceA4?wsdl"
                 )
         elif afip_ws == "ws_sr_padron_a5":
+            if environment_type == "production":
+                afip_ws_url = (
+                    "https://aws.afip.gov.ar/sr-padron/webservices/"
+                    "personaServiceA5?wsdl"
+                )
+            else:
+                afip_ws_url = (
+                    "https://awshomo.afip.gov.ar/sr-padron/webservices/"
+                    "personaServiceA5?wsdl"
+                )
+        elif afip_ws == "ws_sr_constancia_inscripcion":
             if environment_type == "production":
                 afip_ws_url = (
                     "https://aws.afip.gov.ar/sr-padron/webservices/"
@@ -206,7 +218,7 @@ class AfipwsConnection(models.Model):
             from pyafipws.ws_sr_padron import WSSrPadronA4
 
             ws = WSSrPadronA4()
-        elif afip_ws == "ws_sr_padron_a5":
+        elif afip_ws == "ws_sr_padron_a5" or "ws_sr_constancia_inscripcion":
             from pyafipws.ws_sr_padron import WSSrPadronA5
 
             ws = WSSrPadronA5()

--- a/l10n_ar_afipws/models/res_partner.py
+++ b/l10n_ar_afipws/models/res_partner.py
@@ -126,7 +126,7 @@ class ResPartner(models.Model):
             company = certificate.alias_id.company_id
 
         # consultamos a5 ya que extiende a4 y tiene validez de constancia
-        padron = company.get_connection("ws_sr_padron_a5").connect()
+        padron = company.get_connection("ws_sr_constancia_inscripcion").connect()
         error_msg = _(
             "No pudimos actualizar desde padron afip al partner %s (%s).\n"
             "Recomendamos verificar manualmente en la página de AFIP.\n"


### PR DESCRIPTION
Agregado servicio web ws_sr_constancia_inscripcion para que siga funcionando la consulta al Padron A5. En AFIP ya se deshabilitó la posibilidad de asociar este WS por lo que aquellas nuevas compañias que creen un controlador fiscal no podran consumir el ws_sr_padron_a5